### PR TITLE
patches: fix string formatting error

### DIFF
--- a/patches.py
+++ b/patches.py
@@ -129,7 +129,7 @@ def _upscale_uiscript(entry: dbpf.Entry):
             values = part.split("(")[1].split(")")[0]
             for number in values.split(","):
                 new_values.append(str(int(int(number) * UI_MULTIPLIER)))
-            part = f"{name}={part.replace(values, ",".join(new_values))}"
+            part = f"{name}={part.replace(values, ','.join(new_values))}"
             output.append(part)
         return "".join(output)
 


### PR DESCRIPTION
I had an error running the Python code in Ubuntu in WSL. `f-string: unmatched '(' in line with function call` It seems like Python did not like the double quotes inside another set of double quotes. I replaced it with single quotes and it ran fine. I am on Python 3.10.12 which might affect it.

https://stackoverflow.com/questions/67540413/f-string-unmatched-in-line-with-function-call