### PR TITLE
Fix pie menu item positioning at high resolutions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 __pycache__
 /build/
 /dist/
+*.egg-info/
 
 # Optional tests: User must supply files from game
 /tests/gamefiles/*

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 __pycache__
 /build/
 /dist/
-*.egg-info/
 
 # Optional tests: User must supply files from game
 /tests/gamefiles/*

--- a/sims2_4k_ui_patcher.py
+++ b/sims2_4k_ui_patcher.py
@@ -523,13 +523,6 @@ class PatcherApplication(QMainWindow):
         self.btn_revert.clicked.connect(self.revert_patches)
         self.layout_buttons.addWidget(self.btn_revert)
 
-        self.btn_pie_menu = QPushButton()
-        self.btn_pie_menu.setText("Fix Pie Menu")
-        self.btn_pie_menu.setToolTip("Patch only Sims2EP9.exe to fix pie menu positioning.\nUse this if the game is already patched.")
-        self.btn_pie_menu.setEnabled(False)
-        self.btn_pie_menu.clicked.connect(self.patch_pie_menu_only)
-        self.layout_buttons.addWidget(self.btn_pie_menu)
-
         self.btn_patch = QPushButton()
         self.btn_patch.setText("Patch")
         self.btn_patch.setToolTip("Begin the patching process")
@@ -687,7 +680,6 @@ class PatcherApplication(QMainWindow):
         exe_already_patched = any(
             gamefile.GameFileReplacement(p).patched for p in exe_paths
         )
-        self.btn_pie_menu.setEnabled(bool(exe_paths) and not exe_already_patched)
 
         self.tabs.setEnabled(True)
         self.status_progress.setValue(patch_count - update_count)
@@ -856,7 +848,6 @@ class PatcherApplication(QMainWindow):
         # Swap buttons
         self.btn_patch.setHidden(True)
         self.btn_revert.setHidden(True)
-        self.btn_pie_menu.setHidden(True)
         self.btn_details.setHidden(False)
         self.btn_cancel.setHidden(False)
 
@@ -925,7 +916,6 @@ class PatcherApplication(QMainWindow):
         # Swap buttons
         self.btn_patch.setHidden(False)
         self.btn_revert.setHidden(False)
-        self.btn_pie_menu.setHidden(False)
         self.btn_details.setHidden(True)
         self.btn_cancel.setHidden(True)
 
@@ -967,57 +957,6 @@ class PatcherApplication(QMainWindow):
 
         self.state.refresh_file_list()
         self.refresh_patch_state()
-
-    def patch_pie_menu_only(self):
-        """
-        Patch only Sims2EP9.exe to fix pie menu positioning.
-        Useful when the game is already patched and only the EXE fix is needed.
-        """
-        exe_paths = gamefile.get_exe_paths(self.state.game_install_dir)
-        if not exe_paths:
-            QMessageBox.warning(self, "Not Found", "Sims2EP9.exe was not found in the game directory.")
-            return
-
-        self.btn_patch.setEnabled(False)
-        self.btn_revert.setEnabled(False)
-        self.btn_pie_menu.setEnabled(False)
-        self.update_status_icon(StatusIcon.YELLOW)
-        self.status_text.setText("Patching pie menu...")
-
-        patches.UI_MULTIPLIER = self.state.scale
-        patches.FIX_PIE_MENU = True
-        patched_count = 0
-
-        try:
-            for path in exe_paths:
-                exe_file = gamefile.GameFileReplacement(path)
-                if not exe_file.backed_up:
-                    exe_file.backup()
-                patches.process_executable(exe_file)
-                if exe_file.patched:
-                    patched_count += 1
-
-        except PermissionError:
-            self.update_status_icon(StatusIcon.RED)
-            self.status_text.setText("Insufficient file permissions")
-            QMessageBox.critical(self, "Insufficient File Permissions", "Please run this program as an administrator.")
-            self.state.refresh_file_list()
-            self.refresh_patch_state()
-            return
-
-        except Exception as e: # pylint: disable=broad-except
-            QMessageBox.critical(self, "Patch Failed", "An exception occurred.\n\n" + str(e))
-            self.state.refresh_file_list()
-            self.refresh_patch_state()
-            return
-
-        self.state.refresh_file_list()
-        self.refresh_patch_state()
-
-        if patched_count:
-            QMessageBox.information(self, "Pie Menu Fixed", f"Patched {patched_count} executable(s) successfully!")
-        else:
-            QMessageBox.warning(self, "No Changes", "No executables were patched. They may be unsupported versions or already patched.")
 
 
 class QueueWindow(QDialog):

--- a/sims2_4k_ui_patcher.py
+++ b/sims2_4k_ui_patcher.py
@@ -126,6 +126,7 @@ class State:
         # Patch Options
         self.scale: float = 2.0
         self.leave_uncompressed: bool = False
+        self.fix_pie_menu: bool = True
 
         # Experiments
         self.filter: int = Image.Resampling.NEAREST
@@ -136,6 +137,8 @@ class State:
         Return a list of files that will be patched by this program.
         """
         self.game_paths = gamefile.get_patchable_paths(self.game_install_dir)
+        if self.fix_pie_menu:
+            self.game_paths += gamefile.get_exe_paths(self.game_install_dir)
         self.game_files = gamefile.get_patchable_files(self.game_paths)
 
     def set_game_install_path(self, path: str):
@@ -429,6 +432,20 @@ class PatcherApplication(QMainWindow):
         self.compress_option.stateChanged.connect(_compress_changed)
         self.tab_options_layout.addRow("Storage:", self.compress_option)
 
+        def _fix_pie_menu_changed():
+            self.state.fix_pie_menu = self.fix_pie_menu_option.isChecked()
+            self.refresh_patch_state()
+
+        self.fix_pie_menu_option = QCheckBox("Fix pie menu positioning")
+        self.fix_pie_menu_option.setChecked(True)
+        self.fix_pie_menu_option.setToolTip(
+            "Patches Sims2EP9.exe to scale pie menu item positions.\n"
+            "Fixes overlapping/small pie menus at high resolutions.\n"
+            "Only supported for Mansion && Garden Stuff (EP9)."
+        )
+        self.fix_pie_menu_option.stateChanged.connect(_fix_pie_menu_changed)
+        self.tab_options_layout.addRow("Pie Menu:", self.fix_pie_menu_option)
+
         self.tabs.addTab(self.tab_options, "Options")
 
         # Experiments Tab
@@ -505,6 +522,13 @@ class PatcherApplication(QMainWindow):
         self.btn_revert.setEnabled(False)
         self.btn_revert.clicked.connect(self.revert_patches)
         self.layout_buttons.addWidget(self.btn_revert)
+
+        self.btn_pie_menu = QPushButton()
+        self.btn_pie_menu.setText("Fix Pie Menu")
+        self.btn_pie_menu.setToolTip("Patch only Sims2EP9.exe to fix pie menu positioning.\nUse this if the game is already patched.")
+        self.btn_pie_menu.setEnabled(False)
+        self.btn_pie_menu.clicked.connect(self.patch_pie_menu_only)
+        self.layout_buttons.addWidget(self.btn_pie_menu)
 
         self.btn_patch = QPushButton()
         self.btn_patch.setText("Patch")
@@ -659,6 +683,12 @@ class PatcherApplication(QMainWindow):
         if any_backups:
             self.btn_revert.setEnabled(True)
 
+        exe_paths = gamefile.get_exe_paths(self.state.game_install_dir)
+        exe_already_patched = any(
+            gamefile.GameFileReplacement(p).patched for p in exe_paths
+        )
+        self.btn_pie_menu.setEnabled(bool(exe_paths) and not exe_already_patched)
+
         self.tabs.setEnabled(True)
         self.status_progress.setValue(patch_count - update_count)
 
@@ -742,6 +772,7 @@ class PatcherApplication(QMainWindow):
         patches.LEAVE_UNCOMPRESSED = state.leave_uncompressed
         patches.UPSCALE_FILTER = state.filter
         patches.LOADING_SCREEN_FPS = state.loading_screen_fps
+        patches.FIX_PIE_MENU = state.fix_pie_menu
 
         # Begin!
         _update_progress(0, 1)
@@ -825,6 +856,7 @@ class PatcherApplication(QMainWindow):
         # Swap buttons
         self.btn_patch.setHidden(True)
         self.btn_revert.setHidden(True)
+        self.btn_pie_menu.setHidden(True)
         self.btn_details.setHidden(False)
         self.btn_cancel.setHidden(False)
 
@@ -893,6 +925,7 @@ class PatcherApplication(QMainWindow):
         # Swap buttons
         self.btn_patch.setHidden(False)
         self.btn_revert.setHidden(False)
+        self.btn_pie_menu.setHidden(False)
         self.btn_details.setHidden(True)
         self.btn_cancel.setHidden(True)
 
@@ -934,6 +967,57 @@ class PatcherApplication(QMainWindow):
 
         self.state.refresh_file_list()
         self.refresh_patch_state()
+
+    def patch_pie_menu_only(self):
+        """
+        Patch only Sims2EP9.exe to fix pie menu positioning.
+        Useful when the game is already patched and only the EXE fix is needed.
+        """
+        exe_paths = gamefile.get_exe_paths(self.state.game_install_dir)
+        if not exe_paths:
+            QMessageBox.warning(self, "Not Found", "Sims2EP9.exe was not found in the game directory.")
+            return
+
+        self.btn_patch.setEnabled(False)
+        self.btn_revert.setEnabled(False)
+        self.btn_pie_menu.setEnabled(False)
+        self.update_status_icon(StatusIcon.YELLOW)
+        self.status_text.setText("Patching pie menu...")
+
+        patches.UI_MULTIPLIER = self.state.scale
+        patches.FIX_PIE_MENU = True
+        patched_count = 0
+
+        try:
+            for path in exe_paths:
+                exe_file = gamefile.GameFileReplacement(path)
+                if not exe_file.backed_up:
+                    exe_file.backup()
+                patches.process_executable(exe_file)
+                if exe_file.patched:
+                    patched_count += 1
+
+        except PermissionError:
+            self.update_status_icon(StatusIcon.RED)
+            self.status_text.setText("Insufficient file permissions")
+            QMessageBox.critical(self, "Insufficient File Permissions", "Please run this program as an administrator.")
+            self.state.refresh_file_list()
+            self.refresh_patch_state()
+            return
+
+        except Exception as e: # pylint: disable=broad-except
+            QMessageBox.critical(self, "Patch Failed", "An exception occurred.\n\n" + str(e))
+            self.state.refresh_file_list()
+            self.refresh_patch_state()
+            return
+
+        self.state.refresh_file_list()
+        self.refresh_patch_state()
+
+        if patched_count:
+            QMessageBox.information(self, "Pie Menu Fixed", f"Patched {patched_count} executable(s) successfully!")
+        else:
+            QMessageBox.warning(self, "No Changes", "No executables were patched. They may be unsupported versions or already patched.")
 
 
 class QueueWindow(QDialog):

--- a/sims2_4k_ui_patcher.py
+++ b/sims2_4k_ui_patcher.py
@@ -676,11 +676,6 @@ class PatcherApplication(QMainWindow):
         if any_backups:
             self.btn_revert.setEnabled(True)
 
-        exe_paths = gamefile.get_exe_paths(self.state.game_install_dir)
-        exe_already_patched = any(
-            gamefile.GameFileReplacement(p).patched for p in exe_paths
-        )
-
         self.tabs.setEnabled(True)
         self.status_progress.setValue(patch_count - update_count)
 

--- a/sims2patcher/exe_patches.py
+++ b/sims2patcher/exe_patches.py
@@ -1,0 +1,118 @@
+"""
+Module containing upscaling patches and fixes for The Sims 2 executable.
+"""
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Sims2EP9.exe: # The game hardcodes pixel offsets for pie menu item
+# positions. These sector offsets and the item radius calculation
+# need scaling to match the UI density.
+import struct
+
+_PIE_MENU_SECTOR_OFFSETS: list[tuple[int, int]] = [
+    (0x001A6A1E, 0x11),  # edx=17
+    (0x001A6A21, 0x0E),  # eax=14
+    (0x001A6A24, 0x15),  # ecx=21
+    (0x001A6A27, 0x10),  # esi=16
+    (0x001A6A62, 0x30),  # imm32=48
+    (0x001A6A6C, 0x1A),  # imm32=26
+    (0x001A6A9A, 0x1A),  # imm32=26
+]
+
+# Two fild instructions load kItemRadius for the item position formula
+# (radius * sin/cos). A code cave multiplies by UI_MULTIPLIER before
+# the sin/cos multiplication, scaling item positions without affecting
+# the zombie head (3D Sim portrait) which shares the same field.
+_PIE_MENU_FILD_SITE_1 = 0x001A90A9  # fild+fmul for sin path (8 bytes)
+_PIE_MENU_FILD_SITE_2 = 0x001A90C6  # fild+pop+fmul for cos path (9 bytes)
+_PIE_MENU_CAVE_ADDR = 0x00DD2C19    # unused padding at end of .text section
+_PIE_MENU_IMAGE_BASE = 0x00400000
+
+# Expected original bytes at the fild sites for verification
+_PIE_MENU_FILD_ORIG_1 = bytes([0xDB, 0x83, 0xF0, 0x01, 0x00, 0x00, 0xD8, 0xC9])
+_PIE_MENU_FILD_ORIG_2 = bytes([0xDB, 0x83, 0xF0, 0x01, 0x00, 0x00, 0x59, 0xD8, 0xC9])
+
+
+def verify_exe_bytes(data: bytes) -> bool:
+    """Check that the EXE contains expected original bytes at all patch offsets."""
+    for offset, orig_val in _PIE_MENU_SECTOR_OFFSETS:
+        if offset >= len(data) or data[offset] != orig_val:
+            return False
+
+    site1 = _PIE_MENU_FILD_SITE_1
+    site2 = _PIE_MENU_FILD_SITE_2
+    if site1 + 8 > len(data) or site2 + 9 > len(data):
+        return False
+    if data[site1:site1+8] != _PIE_MENU_FILD_ORIG_1:
+        return False
+    if data[site2:site2+9] != _PIE_MENU_FILD_ORIG_2:
+        return False
+
+    return True
+
+
+def build_pie_menu_patch(data: bytes, scale: float) -> bytes:
+    """
+    Apply pie menu positioning fix to the EXE binary data.
+
+    Writes a code cave that multiplies kItemRadius by the scale factor
+    before the sin/cos calculation, and scales sector fine-tuning offsets.
+    """
+    patched = bytearray(data)
+    cave = _PIE_MENU_CAVE_ADDR
+    cave_va = _PIE_MENU_IMAGE_BASE + cave
+
+    # --- Write code cave ---
+    # Layout: [float scale] [cave1: 15 bytes] [cave2: 15 bytes]
+
+    # Float multiplier at cave_addr (4 bytes)
+    struct.pack_into("<f", patched, cave, scale)
+
+    # cave1 at cave+4: fild [ebx+0x1F0]; fmul [multiplier]; fmul st,st1; ret
+    c1 = cave + 4
+    patched[c1:c1+6] = bytes([0xDB, 0x83, 0xF0, 0x01, 0x00, 0x00])  # fild [ebx+0x1F0]
+    patched[c1+6:c1+12] = bytes([0xD8, 0x0D]) + struct.pack("<I", cave_va)  # fmul [cave_va]
+    patched[c1+12:c1+14] = bytes([0xD8, 0xC9])  # fmul st(0), st(1)
+    patched[c1+14] = 0xC3  # ret
+
+    # cave2 at cave+19: same structure
+    c2 = cave + 19
+    patched[c2:c2+6] = bytes([0xDB, 0x83, 0xF0, 0x01, 0x00, 0x00])  # fild [ebx+0x1F0]
+    patched[c2+6:c2+12] = bytes([0xD8, 0x0D]) + struct.pack("<I", cave_va)  # fmul [cave_va]
+    patched[c2+12:c2+14] = bytes([0xD8, 0xC9])  # fmul st(0), st(1)
+    patched[c2+14] = 0xC3  # ret
+
+    # --- Patch call site 1 (sin path, 8 bytes) ---
+    site1 = _PIE_MENU_FILD_SITE_1
+    rel1 = (c1 + _PIE_MENU_IMAGE_BASE) - (site1 + _PIE_MENU_IMAGE_BASE + 5)
+    patched[site1] = 0xE8  # call
+    struct.pack_into("<i", patched, site1 + 1, rel1)
+    patched[site1+5:site1+8] = bytes([0x90, 0x90, 0x90])  # nop pad
+
+    # --- Patch call site 2 (cos path, 9 bytes) ---
+    # Keep the pop ecx at its original position
+    site2 = _PIE_MENU_FILD_SITE_2
+    rel2 = (c2 + _PIE_MENU_IMAGE_BASE) - (site2 + _PIE_MENU_IMAGE_BASE + 5)
+    patched[site2] = 0xE8  # call
+    struct.pack_into("<i", patched, site2 + 1, rel2)
+    patched[site2+5] = 0x59  # pop ecx (stack cleanup, was at site2+6 originally)
+    patched[site2+6:site2+9] = bytes([0x90, 0x90, 0x90])  # nop pad
+
+    # --- Scale sector offsets ---
+    for offset, orig_val in _PIE_MENU_SECTOR_OFFSETS:
+        new_val = min(int(orig_val * scale), 127)
+        patched[offset] = new_val
+
+    return bytes(patched)

--- a/sims2patcher/gamefile.py
+++ b/sims2patcher/gamefile.py
@@ -52,6 +52,14 @@ def get_patchable_paths(install_dir: str) -> list[str]:
     return paths
 
 
+def get_exe_paths(install_dir: str) -> list[str]:
+    """
+    Return paths to Sims2EP9.exe files in the installation directory.
+    Only Sims2EP9.exe is supported for pie menu binary patching.
+    """
+    return glob.glob(install_dir + "/**/Sims2EP9.exe", recursive=True)
+
+
 def get_game_file(path: str) -> 'GameFile':
     """
     Return a game file object for patching.

--- a/sims2patcher/patches.py
+++ b/sims2patcher/patches.py
@@ -24,12 +24,12 @@ interface by doubling the density of graphics and fonts and adjusting UI geometr
 #
 import enum
 import io
-import struct
 from typing import Callable
 
 from PIL import Image
 
 import submodules.SimsReiaParser.SimsReiaPy.sims_reia as sims_reia
+from sims2patcher.exe_patches import build_pie_menu_patch, verify_exe_bytes
 
 from . import dbpf, errors, gamefile, uiscript
 
@@ -39,7 +39,7 @@ UI_MULTIPLIER: float = 2.0
 # Compression keeps the package files small, but takes longer to process
 LEAVE_UNCOMPRESSED: bool = False
 
-# Fix pie menu item positioning in the game executable
+# Patch the executable to fix the pie menu item positioning
 FIX_PIE_MENU: bool = True
 
 # Image upscaling filter
@@ -454,123 +454,20 @@ def process_fontstyle_ini(file: gamefile.GameFile, write_meta_file=True):
         file.write_meta_file()
 
 
-# Pie menu binary patch data for Sims2EP9.exe.
-# The game hardcodes pixel offsets for pie menu item positions. These sector
-# offsets and the item radius calculation need scaling to match the UI density.
-_PIE_MENU_SECTOR_OFFSETS: list[tuple[int, int]] = [
-    (0x001A6A1E, 0x11),  # edx=17
-    (0x001A6A21, 0x0E),  # eax=14
-    (0x001A6A24, 0x15),  # ecx=21
-    (0x001A6A27, 0x10),  # esi=16
-    (0x001A6A62, 0x30),  # imm32=48
-    (0x001A6A6C, 0x1A),  # imm32=26
-    (0x001A6A9A, 0x1A),  # imm32=26
-]
-
-# Two fild instructions load kItemRadius for the item position formula
-# (radius * sin/cos). A code cave multiplies by UI_MULTIPLIER before
-# the sin/cos multiplication, scaling item positions without affecting
-# the zombie head (3D Sim portrait) which shares the same field.
-_PIE_MENU_FILD_SITE_1 = 0x001A90A9  # fild+fmul for sin path (8 bytes)
-_PIE_MENU_FILD_SITE_2 = 0x001A90C6  # fild+pop+fmul for cos path (9 bytes)
-_PIE_MENU_CAVE_ADDR = 0x00DD2C19    # unused padding at end of .text section
-_PIE_MENU_IMAGE_BASE = 0x00400000
-
-# Expected original bytes at the fild sites for verification
-_PIE_MENU_FILD_ORIG_1 = bytes([0xDB, 0x83, 0xF0, 0x01, 0x00, 0x00, 0xD8, 0xC9])
-_PIE_MENU_FILD_ORIG_2 = bytes([0xDB, 0x83, 0xF0, 0x01, 0x00, 0x00, 0x59, 0xD8, 0xC9])
-
-
-def _verify_exe_bytes(data: bytes) -> bool:
-    """Check that the EXE contains expected original bytes at all patch offsets."""
-    for offset, orig_val in _PIE_MENU_SECTOR_OFFSETS:
-        if offset >= len(data) or data[offset] != orig_val:
-            return False
-
-    site1 = _PIE_MENU_FILD_SITE_1
-    site2 = _PIE_MENU_FILD_SITE_2
-    if site1 + 8 > len(data) or site2 + 9 > len(data):
-        return False
-    if data[site1:site1+8] != _PIE_MENU_FILD_ORIG_1:
-        return False
-    if data[site2:site2+9] != _PIE_MENU_FILD_ORIG_2:
-        return False
-
-    return True
-
-
-def _build_pie_menu_patch(data: bytes, scale: float) -> bytes:
-    """
-    Apply pie menu positioning fix to the EXE binary data.
-
-    Writes a code cave that multiplies kItemRadius by the scale factor
-    before the sin/cos calculation, and scales sector fine-tuning offsets.
-    """
-    patched = bytearray(data)
-    cave = _PIE_MENU_CAVE_ADDR
-    cave_va = _PIE_MENU_IMAGE_BASE + cave
-
-    # --- Write code cave ---
-    # Layout: [float scale] [cave1: 15 bytes] [cave2: 15 bytes]
-
-    # Float multiplier at cave_addr (4 bytes)
-    struct.pack_into("<f", patched, cave, scale)
-
-    # cave1 at cave+4: fild [ebx+0x1F0]; fmul [multiplier]; fmul st,st1; ret
-    c1 = cave + 4
-    patched[c1:c1+6] = bytes([0xDB, 0x83, 0xF0, 0x01, 0x00, 0x00])  # fild [ebx+0x1F0]
-    patched[c1+6:c1+12] = bytes([0xD8, 0x0D]) + struct.pack("<I", cave_va)  # fmul [cave_va]
-    patched[c1+12:c1+14] = bytes([0xD8, 0xC9])  # fmul st(0), st(1)
-    patched[c1+14] = 0xC3  # ret
-
-    # cave2 at cave+19: same structure
-    c2 = cave + 19
-    patched[c2:c2+6] = bytes([0xDB, 0x83, 0xF0, 0x01, 0x00, 0x00])  # fild [ebx+0x1F0]
-    patched[c2+6:c2+12] = bytes([0xD8, 0x0D]) + struct.pack("<I", cave_va)  # fmul [cave_va]
-    patched[c2+12:c2+14] = bytes([0xD8, 0xC9])  # fmul st(0), st(1)
-    patched[c2+14] = 0xC3  # ret
-
-    # --- Patch call site 1 (sin path, 8 bytes) ---
-    site1 = _PIE_MENU_FILD_SITE_1
-    rel1 = (c1 + _PIE_MENU_IMAGE_BASE) - (site1 + _PIE_MENU_IMAGE_BASE + 5)
-    patched[site1] = 0xE8  # call
-    struct.pack_into("<i", patched, site1 + 1, rel1)
-    patched[site1+5:site1+8] = bytes([0x90, 0x90, 0x90])  # nop pad
-
-    # --- Patch call site 2 (cos path, 9 bytes) ---
-    # Keep the pop ecx at its original position
-    site2 = _PIE_MENU_FILD_SITE_2
-    rel2 = (c2 + _PIE_MENU_IMAGE_BASE) - (site2 + _PIE_MENU_IMAGE_BASE + 5)
-    patched[site2] = 0xE8  # call
-    struct.pack_into("<i", patched, site2 + 1, rel2)
-    patched[site2+5] = 0x59  # pop ecx (stack cleanup, was at site2+6 originally)
-    patched[site2+6:site2+9] = bytes([0x90, 0x90, 0x90])  # nop pad
-
-    # --- Scale sector offsets ---
-    for offset, orig_val in _PIE_MENU_SECTOR_OFFSETS:
-        new_val = min(int(orig_val * scale), 127)
-        patched[offset] = new_val
-
-    return bytes(patched)
-
-
 def process_executable(file: gamefile.GameFile):
     """
     Patches the game executable to fix pie menu item positioning.
     Applies a code cave to scale the item radius calculation and
     adjusts sector fine-tuning offsets.
     """
-    if not FIX_PIE_MENU:
-        return
-
     with open(file.original_file_path, "rb") as f:
         data = f.read()
 
-    if not _verify_exe_bytes(data):
+    if not verify_exe_bytes(data):
         print(f"Skipping pie menu fix: {file.filename} has unexpected bytes (unsupported version or already patched)")
         return
 
-    patched_data = _build_pie_menu_patch(data, UI_MULTIPLIER)
+    patched_data = build_pie_menu_patch(data, UI_MULTIPLIER)
 
     with open(file.target_file_path, "wb") as f:
         f.write(patched_data)
@@ -589,7 +486,7 @@ def patch_file(file: gamefile.GameFile, ui_update_progress: Callable):
     elif file.filename in ["ui.package", "CaSIEUI.data", "objects.package"]:
         process_package(file, ui_update_progress)
 
-    elif file.filename.lower() == "sims2ep9.exe":
+    elif file.filename.lower() == "sims2ep9.exe" and FIX_PIE_MENU:
         process_executable(file)
 
     else:

--- a/sims2patcher/patches.py
+++ b/sims2patcher/patches.py
@@ -24,6 +24,7 @@ interface by doubling the density of graphics and fonts and adjusting UI geometr
 #
 import enum
 import io
+import struct
 from typing import Callable
 
 from PIL import Image
@@ -37,6 +38,9 @@ UI_MULTIPLIER: float = 2.0
 
 # Compression keeps the package files small, but takes longer to process
 LEAVE_UNCOMPRESSED: bool = False
+
+# Fix pie menu item positioning in the game executable
+FIX_PIE_MENU: bool = True
 
 # Image upscaling filter
 UPSCALE_FILTER: Image.Resampling = Image.Resampling.NEAREST
@@ -450,6 +454,131 @@ def process_fontstyle_ini(file: gamefile.GameFile, write_meta_file=True):
         file.write_meta_file()
 
 
+# Pie menu binary patch data for Sims2EP9.exe.
+# The game hardcodes pixel offsets for pie menu item positions. These sector
+# offsets and the item radius calculation need scaling to match the UI density.
+_PIE_MENU_SECTOR_OFFSETS: list[tuple[int, int]] = [
+    (0x001A6A1E, 0x11),  # edx=17
+    (0x001A6A21, 0x0E),  # eax=14
+    (0x001A6A24, 0x15),  # ecx=21
+    (0x001A6A27, 0x10),  # esi=16
+    (0x001A6A62, 0x30),  # imm32=48
+    (0x001A6A6C, 0x1A),  # imm32=26
+    (0x001A6A9A, 0x1A),  # imm32=26
+]
+
+# Two fild instructions load kItemRadius for the item position formula
+# (radius * sin/cos). A code cave multiplies by UI_MULTIPLIER before
+# the sin/cos multiplication, scaling item positions without affecting
+# the zombie head (3D Sim portrait) which shares the same field.
+_PIE_MENU_FILD_SITE_1 = 0x001A90A9  # fild+fmul for sin path (8 bytes)
+_PIE_MENU_FILD_SITE_2 = 0x001A90C6  # fild+pop+fmul for cos path (9 bytes)
+_PIE_MENU_CAVE_ADDR = 0x00DD2C19    # unused padding at end of .text section
+_PIE_MENU_IMAGE_BASE = 0x00400000
+
+# Expected original bytes at the fild sites for verification
+_PIE_MENU_FILD_ORIG_1 = bytes([0xDB, 0x83, 0xF0, 0x01, 0x00, 0x00, 0xD8, 0xC9])
+_PIE_MENU_FILD_ORIG_2 = bytes([0xDB, 0x83, 0xF0, 0x01, 0x00, 0x00, 0x59, 0xD8, 0xC9])
+
+
+def _verify_exe_bytes(data: bytes) -> bool:
+    """Check that the EXE contains expected original bytes at all patch offsets."""
+    for offset, orig_val in _PIE_MENU_SECTOR_OFFSETS:
+        if offset >= len(data) or data[offset] != orig_val:
+            return False
+
+    site1 = _PIE_MENU_FILD_SITE_1
+    site2 = _PIE_MENU_FILD_SITE_2
+    if site1 + 8 > len(data) or site2 + 9 > len(data):
+        return False
+    if data[site1:site1+8] != _PIE_MENU_FILD_ORIG_1:
+        return False
+    if data[site2:site2+9] != _PIE_MENU_FILD_ORIG_2:
+        return False
+
+    return True
+
+
+def _build_pie_menu_patch(data: bytes, scale: float) -> bytes:
+    """
+    Apply pie menu positioning fix to the EXE binary data.
+
+    Writes a code cave that multiplies kItemRadius by the scale factor
+    before the sin/cos calculation, and scales sector fine-tuning offsets.
+    """
+    patched = bytearray(data)
+    cave = _PIE_MENU_CAVE_ADDR
+    cave_va = _PIE_MENU_IMAGE_BASE + cave
+
+    # --- Write code cave ---
+    # Layout: [float scale] [cave1: 15 bytes] [cave2: 15 bytes]
+
+    # Float multiplier at cave_addr (4 bytes)
+    struct.pack_into("<f", patched, cave, scale)
+
+    # cave1 at cave+4: fild [ebx+0x1F0]; fmul [multiplier]; fmul st,st1; ret
+    c1 = cave + 4
+    patched[c1:c1+6] = bytes([0xDB, 0x83, 0xF0, 0x01, 0x00, 0x00])  # fild [ebx+0x1F0]
+    patched[c1+6:c1+12] = bytes([0xD8, 0x0D]) + struct.pack("<I", cave_va)  # fmul [cave_va]
+    patched[c1+12:c1+14] = bytes([0xD8, 0xC9])  # fmul st(0), st(1)
+    patched[c1+14] = 0xC3  # ret
+
+    # cave2 at cave+19: same structure
+    c2 = cave + 19
+    patched[c2:c2+6] = bytes([0xDB, 0x83, 0xF0, 0x01, 0x00, 0x00])  # fild [ebx+0x1F0]
+    patched[c2+6:c2+12] = bytes([0xD8, 0x0D]) + struct.pack("<I", cave_va)  # fmul [cave_va]
+    patched[c2+12:c2+14] = bytes([0xD8, 0xC9])  # fmul st(0), st(1)
+    patched[c2+14] = 0xC3  # ret
+
+    # --- Patch call site 1 (sin path, 8 bytes) ---
+    site1 = _PIE_MENU_FILD_SITE_1
+    rel1 = (c1 + _PIE_MENU_IMAGE_BASE) - (site1 + _PIE_MENU_IMAGE_BASE + 5)
+    patched[site1] = 0xE8  # call
+    struct.pack_into("<i", patched, site1 + 1, rel1)
+    patched[site1+5:site1+8] = bytes([0x90, 0x90, 0x90])  # nop pad
+
+    # --- Patch call site 2 (cos path, 9 bytes) ---
+    # Keep the pop ecx at its original position
+    site2 = _PIE_MENU_FILD_SITE_2
+    rel2 = (c2 + _PIE_MENU_IMAGE_BASE) - (site2 + _PIE_MENU_IMAGE_BASE + 5)
+    patched[site2] = 0xE8  # call
+    struct.pack_into("<i", patched, site2 + 1, rel2)
+    patched[site2+5] = 0x59  # pop ecx (stack cleanup, was at site2+6 originally)
+    patched[site2+6:site2+9] = bytes([0x90, 0x90, 0x90])  # nop pad
+
+    # --- Scale sector offsets ---
+    for offset, orig_val in _PIE_MENU_SECTOR_OFFSETS:
+        new_val = min(int(orig_val * scale), 127)
+        patched[offset] = new_val
+
+    return bytes(patched)
+
+
+def process_executable(file: gamefile.GameFile):
+    """
+    Patches the game executable to fix pie menu item positioning.
+    Applies a code cave to scale the item radius calculation and
+    adjusts sector fine-tuning offsets.
+    """
+    if not FIX_PIE_MENU:
+        return
+
+    with open(file.original_file_path, "rb") as f:
+        data = f.read()
+
+    if not _verify_exe_bytes(data):
+        print(f"Skipping pie menu fix: {file.filename} has unexpected bytes (unsupported version or already patched)")
+        return
+
+    patched_data = _build_pie_menu_patch(data, UI_MULTIPLIER)
+
+    with open(file.target_file_path, "wb") as f:
+        f.write(patched_data)
+
+    file.patched = True
+    file.write_meta_file()
+
+
 def patch_file(file: gamefile.GameFile, ui_update_progress: Callable):
     """
     Patch a file with the appropriate function based on the filename.
@@ -459,6 +588,9 @@ def patch_file(file: gamefile.GameFile, ui_update_progress: Callable):
 
     elif file.filename in ["ui.package", "CaSIEUI.data", "objects.package"]:
         process_package(file, ui_update_progress)
+
+    elif file.filename.lower() == "sims2ep9.exe":
+        process_executable(file)
 
     else:
         raise NotImplementedError(f"Unknown patch operation: {file.file_path}")

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -6,6 +6,7 @@ and output works as expected.
 import io
 import os
 import shutil
+import struct
 import sys
 
 import PIL.Image
@@ -114,3 +115,130 @@ class UIScriptTest(BaseTestCase):
         result = patches._upscale_uiscript(entry)
         expected = b"# Test\r\n<LEGACY iid=IGZWinGen area=(10,20,30,40) >\r\n<LEGACY iid=IGZWinText caption=\"Needs\" font=GenHeader >\r\n"
         self.assertEqual(result, expected, "UI script was not upscaled as expected")
+
+
+class ExecutablePatchTest(BaseTestCase):
+    """
+    Test the pie menu binary patching for Sims2EP9.exe.
+    Uses synthetic data — no real game executable needed.
+    """
+    def _make_fake_exe(self) -> bytearray:
+        """Create a minimal bytearray with correct original bytes at all patch offsets."""
+        max_offset = max(
+            max(o for o, _ in patches._PIE_MENU_SECTOR_OFFSETS),
+            patches._PIE_MENU_FILD_SITE_2 + 9,
+            patches._PIE_MENU_CAVE_ADDR + 40,
+        )
+        data = bytearray(max_offset + 64)
+        for offset, orig_val in patches._PIE_MENU_SECTOR_OFFSETS:
+            data[offset] = orig_val
+        site1 = patches._PIE_MENU_FILD_SITE_1
+        data[site1:site1+8] = patches._PIE_MENU_FILD_ORIG_1
+        site2 = patches._PIE_MENU_FILD_SITE_2
+        data[site2:site2+9] = patches._PIE_MENU_FILD_ORIG_2
+        return data
+
+    def test_verify_original_passes(self):
+        """Verification passes for unmodified original bytes"""
+        data = bytes(self._make_fake_exe())
+        self.assertTrue(patches._verify_exe_bytes(data))
+
+    def test_verify_wrong_bytes_fails(self):
+        """Verification fails when bytes don't match"""
+        data = self._make_fake_exe()
+        data[patches._PIE_MENU_SECTOR_OFFSETS[0][0]] = 0xFF
+        self.assertFalse(patches._verify_exe_bytes(bytes(data)))
+
+    def test_verify_wrong_fild_fails(self):
+        """Verification fails when fild site bytes don't match"""
+        data = self._make_fake_exe()
+        data[patches._PIE_MENU_FILD_SITE_1] = 0x00
+        self.assertFalse(patches._verify_exe_bytes(bytes(data)))
+
+    def test_sector_offsets_scaled_2x(self):
+        """Sector offsets are doubled at 2.0x scale"""
+        data = bytes(self._make_fake_exe())
+        result = patches._build_pie_menu_patch(data, 2.0)
+        for offset, orig_val in patches._PIE_MENU_SECTOR_OFFSETS:
+            expected = min(int(orig_val * 2.0), 127)
+            self.assertEqual(result[offset], expected,
+                f"Sector offset at 0x{offset:X}: expected {expected}, got {result[offset]}")
+
+    def test_sector_offsets_scaled_1_5x(self):
+        """Sector offsets are correctly scaled at 1.5x"""
+        data = bytes(self._make_fake_exe())
+        result = patches._build_pie_menu_patch(data, 1.5)
+        for offset, orig_val in patches._PIE_MENU_SECTOR_OFFSETS:
+            expected = min(int(orig_val * 1.5), 127)
+            self.assertEqual(result[offset], expected)
+
+    def test_sector_offset_capped_at_127(self):
+        """Scaled values exceeding 127 are capped (signed byte limit)"""
+        data = bytes(self._make_fake_exe())
+        result = patches._build_pie_menu_patch(data, 3.0)
+        offset_48 = 0x001A6A62
+        self.assertEqual(result[offset_48], 127, "48 * 3 = 144 should be capped to 127")
+
+    def test_code_cave_written(self):
+        """Code cave is written at the correct address with multiplier float"""
+        data = bytes(self._make_fake_exe())
+        result = patches._build_pie_menu_patch(data, 2.0)
+        cave = patches._PIE_MENU_CAVE_ADDR
+        stored_float = struct.unpack_from("<f", result, cave)[0]
+        self.assertAlmostEqual(stored_float, 2.0, places=5, msg="Multiplier float not stored correctly")
+        self.assertEqual(result[cave + 4], 0xDB, "Cave1 should start with fild opcode")
+        self.assertEqual(result[cave + 4 + 14], 0xC3, "Cave1 should end with ret")
+        self.assertEqual(result[cave + 19], 0xDB, "Cave2 should start with fild opcode")
+        self.assertEqual(result[cave + 19 + 14], 0xC3, "Cave2 should end with ret")
+
+    def test_call_site_1_redirected(self):
+        """First fild+fmul site is replaced with call to cave + nops"""
+        data = bytes(self._make_fake_exe())
+        result = patches._build_pie_menu_patch(data, 2.0)
+        site1 = patches._PIE_MENU_FILD_SITE_1
+        self.assertEqual(result[site1], 0xE8, "Site 1 should have call opcode")
+        self.assertEqual(result[site1+5:site1+8], bytes([0x90, 0x90, 0x90]), "Site 1 should be nop-padded")
+
+    def test_call_site_2_redirected(self):
+        """Second fild site is replaced with call + pop ecx + nops"""
+        data = bytes(self._make_fake_exe())
+        result = patches._build_pie_menu_patch(data, 2.0)
+        site2 = patches._PIE_MENU_FILD_SITE_2
+        self.assertEqual(result[site2], 0xE8, "Site 2 should have call opcode")
+        self.assertEqual(result[site2+5], 0x59, "Site 2 should keep pop ecx")
+        self.assertEqual(result[site2+6:site2+9], bytes([0x90, 0x90, 0x90]), "Site 2 should be nop-padded")
+
+    def test_call_targets_are_correct(self):
+        """Call instructions point to the correct cave addresses"""
+        data = bytes(self._make_fake_exe())
+        result = patches._build_pie_menu_patch(data, 2.0)
+        cave = patches._PIE_MENU_CAVE_ADDR
+        base = patches._PIE_MENU_IMAGE_BASE
+
+        site1 = patches._PIE_MENU_FILD_SITE_1
+        rel1 = struct.unpack_from("<i", result, site1 + 1)[0]
+        target1 = site1 + 5 + rel1
+        self.assertEqual(target1, cave + 4, "Call site 1 should target cave1")
+
+        site2 = patches._PIE_MENU_FILD_SITE_2
+        rel2 = struct.unpack_from("<i", result, site2 + 1)[0]
+        target2 = site2 + 5 + rel2
+        self.assertEqual(target2, cave + 19, "Call site 2 should target cave2")
+
+    def test_unpatched_bytes_preserved(self):
+        """Bytes outside patch areas remain unchanged"""
+        data = bytes(self._make_fake_exe())
+        result = patches._build_pie_menu_patch(data, 2.0)
+        patch_ranges = set()
+        for offset, _ in patches._PIE_MENU_SECTOR_OFFSETS:
+            patch_ranges.add(offset)
+        for i in range(patches._PIE_MENU_FILD_SITE_1, patches._PIE_MENU_FILD_SITE_1 + 8):
+            patch_ranges.add(i)
+        for i in range(patches._PIE_MENU_FILD_SITE_2, patches._PIE_MENU_FILD_SITE_2 + 9):
+            patch_ranges.add(i)
+        for i in range(patches._PIE_MENU_CAVE_ADDR, patches._PIE_MENU_CAVE_ADDR + 40):
+            patch_ranges.add(i)
+        for i in range(min(len(data), len(result))):
+            if i not in patch_ranges:
+                self.assertEqual(result[i], data[i],
+                    f"Byte at 0x{i:X} was unexpectedly modified")

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -213,7 +213,6 @@ class ExecutablePatchTest(BaseTestCase):
         data = bytes(self._make_fake_exe())
         result = patches._build_pie_menu_patch(data, 2.0)
         cave = patches._PIE_MENU_CAVE_ADDR
-        base = patches._PIE_MENU_IMAGE_BASE
 
         site1 = patches._PIE_MENU_FILD_SITE_1
         rel1 = struct.unpack_from("<i", result, site1 + 1)[0]

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -14,7 +14,7 @@ import PIL.Image
 # Our modules are in the parent directory
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))) # pylint: disable=wrong-import-position
 
-from sims2patcher import dbpf, patches
+from sims2patcher import dbpf, exe_patches, patches
 from sims2patcher.dbpf import TYPE_IMAGE, Entry
 from sims2patcher.gamefile import GameFileReplacement
 from tests.test_base import BaseTestCase
@@ -125,41 +125,41 @@ class ExecutablePatchTest(BaseTestCase):
     def _make_fake_exe(self) -> bytearray:
         """Create a minimal bytearray with correct original bytes at all patch offsets."""
         max_offset = max(
-            max(o for o, _ in patches._PIE_MENU_SECTOR_OFFSETS),
-            patches._PIE_MENU_FILD_SITE_2 + 9,
-            patches._PIE_MENU_CAVE_ADDR + 40,
+            max(o for o, _ in exe_patches._PIE_MENU_SECTOR_OFFSETS),
+            exe_patches._PIE_MENU_FILD_SITE_2 + 9,
+            exe_patches._PIE_MENU_CAVE_ADDR + 40,
         )
         data = bytearray(max_offset + 64)
-        for offset, orig_val in patches._PIE_MENU_SECTOR_OFFSETS:
+        for offset, orig_val in exe_patches._PIE_MENU_SECTOR_OFFSETS:
             data[offset] = orig_val
-        site1 = patches._PIE_MENU_FILD_SITE_1
-        data[site1:site1+8] = patches._PIE_MENU_FILD_ORIG_1
-        site2 = patches._PIE_MENU_FILD_SITE_2
-        data[site2:site2+9] = patches._PIE_MENU_FILD_ORIG_2
+        site1 = exe_patches._PIE_MENU_FILD_SITE_1
+        data[site1:site1+8] = exe_patches._PIE_MENU_FILD_ORIG_1
+        site2 = exe_patches._PIE_MENU_FILD_SITE_2
+        data[site2:site2+9] = exe_patches._PIE_MENU_FILD_ORIG_2
         return data
 
     def test_verify_original_passes(self):
         """Verification passes for unmodified original bytes"""
         data = bytes(self._make_fake_exe())
-        self.assertTrue(patches._verify_exe_bytes(data))
+        self.assertTrue(exe_patches.verify_exe_bytes(data))
 
     def test_verify_wrong_bytes_fails(self):
         """Verification fails when bytes don't match"""
         data = self._make_fake_exe()
-        data[patches._PIE_MENU_SECTOR_OFFSETS[0][0]] = 0xFF
-        self.assertFalse(patches._verify_exe_bytes(bytes(data)))
+        data[exe_patches._PIE_MENU_SECTOR_OFFSETS[0][0]] = 0xFF
+        self.assertFalse(exe_patches.verify_exe_bytes(bytes(data)))
 
     def test_verify_wrong_fild_fails(self):
         """Verification fails when fild site bytes don't match"""
         data = self._make_fake_exe()
-        data[patches._PIE_MENU_FILD_SITE_1] = 0x00
-        self.assertFalse(patches._verify_exe_bytes(bytes(data)))
+        data[exe_patches._PIE_MENU_FILD_SITE_1] = 0x00
+        self.assertFalse(exe_patches.verify_exe_bytes(bytes(data)))
 
     def test_sector_offsets_scaled_2x(self):
         """Sector offsets are doubled at 2.0x scale"""
         data = bytes(self._make_fake_exe())
-        result = patches._build_pie_menu_patch(data, 2.0)
-        for offset, orig_val in patches._PIE_MENU_SECTOR_OFFSETS:
+        result = exe_patches.build_pie_menu_patch(data, 2.0)
+        for offset, orig_val in exe_patches._PIE_MENU_SECTOR_OFFSETS:
             expected = min(int(orig_val * 2.0), 127)
             self.assertEqual(result[offset], expected,
                 f"Sector offset at 0x{offset:X}: expected {expected}, got {result[offset]}")
@@ -167,23 +167,23 @@ class ExecutablePatchTest(BaseTestCase):
     def test_sector_offsets_scaled_1_5x(self):
         """Sector offsets are correctly scaled at 1.5x"""
         data = bytes(self._make_fake_exe())
-        result = patches._build_pie_menu_patch(data, 1.5)
-        for offset, orig_val in patches._PIE_MENU_SECTOR_OFFSETS:
+        result = exe_patches.build_pie_menu_patch(data, 1.5)
+        for offset, orig_val in exe_patches._PIE_MENU_SECTOR_OFFSETS:
             expected = min(int(orig_val * 1.5), 127)
             self.assertEqual(result[offset], expected)
 
     def test_sector_offset_capped_at_127(self):
         """Scaled values exceeding 127 are capped (signed byte limit)"""
         data = bytes(self._make_fake_exe())
-        result = patches._build_pie_menu_patch(data, 3.0)
+        result = exe_patches.build_pie_menu_patch(data, 3.0)
         offset_48 = 0x001A6A62
         self.assertEqual(result[offset_48], 127, "48 * 3 = 144 should be capped to 127")
 
     def test_code_cave_written(self):
         """Code cave is written at the correct address with multiplier float"""
         data = bytes(self._make_fake_exe())
-        result = patches._build_pie_menu_patch(data, 2.0)
-        cave = patches._PIE_MENU_CAVE_ADDR
+        result = exe_patches.build_pie_menu_patch(data, 2.0)
+        cave = exe_patches._PIE_MENU_CAVE_ADDR
         stored_float = struct.unpack_from("<f", result, cave)[0]
         self.assertAlmostEqual(stored_float, 2.0, places=5, msg="Multiplier float not stored correctly")
         self.assertEqual(result[cave + 4], 0xDB, "Cave1 should start with fild opcode")
@@ -194,16 +194,16 @@ class ExecutablePatchTest(BaseTestCase):
     def test_call_site_1_redirected(self):
         """First fild+fmul site is replaced with call to cave + nops"""
         data = bytes(self._make_fake_exe())
-        result = patches._build_pie_menu_patch(data, 2.0)
-        site1 = patches._PIE_MENU_FILD_SITE_1
+        result = exe_patches.build_pie_menu_patch(data, 2.0)
+        site1 = exe_patches._PIE_MENU_FILD_SITE_1
         self.assertEqual(result[site1], 0xE8, "Site 1 should have call opcode")
         self.assertEqual(result[site1+5:site1+8], bytes([0x90, 0x90, 0x90]), "Site 1 should be nop-padded")
 
     def test_call_site_2_redirected(self):
         """Second fild site is replaced with call + pop ecx + nops"""
         data = bytes(self._make_fake_exe())
-        result = patches._build_pie_menu_patch(data, 2.0)
-        site2 = patches._PIE_MENU_FILD_SITE_2
+        result = exe_patches.build_pie_menu_patch(data, 2.0)
+        site2 = exe_patches._PIE_MENU_FILD_SITE_2
         self.assertEqual(result[site2], 0xE8, "Site 2 should have call opcode")
         self.assertEqual(result[site2+5], 0x59, "Site 2 should keep pop ecx")
         self.assertEqual(result[site2+6:site2+9], bytes([0x90, 0x90, 0x90]), "Site 2 should be nop-padded")
@@ -211,15 +211,15 @@ class ExecutablePatchTest(BaseTestCase):
     def test_call_targets_are_correct(self):
         """Call instructions point to the correct cave addresses"""
         data = bytes(self._make_fake_exe())
-        result = patches._build_pie_menu_patch(data, 2.0)
-        cave = patches._PIE_MENU_CAVE_ADDR
+        result = exe_patches.build_pie_menu_patch(data, 2.0)
+        cave = exe_patches._PIE_MENU_CAVE_ADDR
 
-        site1 = patches._PIE_MENU_FILD_SITE_1
+        site1 = exe_patches._PIE_MENU_FILD_SITE_1
         rel1 = struct.unpack_from("<i", result, site1 + 1)[0]
         target1 = site1 + 5 + rel1
         self.assertEqual(target1, cave + 4, "Call site 1 should target cave1")
 
-        site2 = patches._PIE_MENU_FILD_SITE_2
+        site2 = exe_patches._PIE_MENU_FILD_SITE_2
         rel2 = struct.unpack_from("<i", result, site2 + 1)[0]
         target2 = site2 + 5 + rel2
         self.assertEqual(target2, cave + 19, "Call site 2 should target cave2")
@@ -227,15 +227,15 @@ class ExecutablePatchTest(BaseTestCase):
     def test_unpatched_bytes_preserved(self):
         """Bytes outside patch areas remain unchanged"""
         data = bytes(self._make_fake_exe())
-        result = patches._build_pie_menu_patch(data, 2.0)
+        result = exe_patches.build_pie_menu_patch(data, 2.0)
         patch_ranges = set()
-        for offset, _ in patches._PIE_MENU_SECTOR_OFFSETS:
+        for offset, _ in exe_patches._PIE_MENU_SECTOR_OFFSETS:
             patch_ranges.add(offset)
-        for i in range(patches._PIE_MENU_FILD_SITE_1, patches._PIE_MENU_FILD_SITE_1 + 8):
+        for i in range(exe_patches._PIE_MENU_FILD_SITE_1, exe_patches._PIE_MENU_FILD_SITE_1 + 8):
             patch_ranges.add(i)
-        for i in range(patches._PIE_MENU_FILD_SITE_2, patches._PIE_MENU_FILD_SITE_2 + 9):
+        for i in range(exe_patches._PIE_MENU_FILD_SITE_2, exe_patches._PIE_MENU_FILD_SITE_2 + 9):
             patch_ranges.add(i)
-        for i in range(patches._PIE_MENU_CAVE_ADDR, patches._PIE_MENU_CAVE_ADDR + 40):
+        for i in range(exe_patches._PIE_MENU_CAVE_ADDR, exe_patches._PIE_MENU_CAVE_ADDR + 40):
             patch_ranges.add(i)
         for i in range(min(len(data), len(result))):
             if i not in patch_ranges:


### PR DESCRIPTION
## Summary

This PR fixes the long-standing pie menu issue (#20) where menu items overlap and appear small at HiDPI resolutions. The root cause is that the game's executable (`Sims2EP9.exe`) hardcodes the pixel offsets used to position pie menu items — something the existing UI script / package patching can't reach.

The fix applies a binary patch (code cave) to the game executable that scales the item radius calculation by `UI_MULTIPLIER`, matching the rest of the scaled UI. It also doubles the per-sector fine-tuning offsets that control text alignment within each pie menu sector.

> **Disclaimer:** I don't have deep knowledge of Lua or the Sims 2 engine internals. This PR was born from a vibe-coding session with Claude Code (AI assistant) and a strong desire to make my wife's favourite game look right on her 1440p monitor. The reverse engineering was done empirically — patching bytes, launching the game, observing results, repeat. It works on my Mansion & Garden Stuff (EP9) Ultimate Collection install, but hasn't been tested on other versions.

## Before / After

Before:
<img width="1059" height="343" alt="piebroken" src="https://github.com/user-attachments/assets/47dd64b1-98bf-4810-b13c-a6420c9945ab" />

After:
<img width="1215" height="477" alt="piefix" src="https://github.com/user-attachments/assets/75bb8e59-f808-4c41-8f4a-fbafc81ae4d4" />

## How it works

The game positions pie menu items using this formula in compiled C++ code:

```
x = center_x + kItemRadius * cos(angle)
y = center_y + kItemRadius * sin(angle)
```

`kItemRadius` is read from the UI script and stored at object offset `+0x1F0`. The existing patcher already scales this value in `ui.package`, but the same field is also used for the 3D Sim portrait ("zombie head") positioning. Scaling it through the UI script alone moves the head but — as the issue author noted — the actual pie menu items are positioned by separate hardcoded game code that we couldn't previously reach.

**What we found through reverse engineering:**

1. **Two `fild` instructions** (at file offsets `0x001A90A9` and `0x001A90C6`) load `kItemRadius` and multiply by `sin`/`cos` to compute item X/Y positions.

2. **Seven sector offset bytes** (at `0x001A6A1E`–`0x001A6A9A`) control per-sector alignment of item text — values like 14, 16, 17, 21, 26, and 48 pixels.

3. **999 bytes of padding** at the end of the `.text` section (`0x00DD2C19`) — a perfect code cave.

**The patch writes a small code cave** that loads `kItemRadius`, multiplies by `UI_MULTIPLIER` (stored as a float in the cave), then multiplies by `sin`/`cos` — before returning to the original code. This doubles the item radius **only for the item positioning formula**, without affecting the zombie head, camera, or mouse detection zones. The sector offsets are also scaled proportionally.

## What changed

| File | Change |
|------|--------|
| `sims2patcher/patches.py` | Added `process_executable()`, code cave builder, byte verification, sector offset scaling |
| `sims2patcher/gamefile.py` | Added `get_exe_paths()` to find `Sims2EP9.exe` in `TSBin/` |
| `sims2_4k_ui_patcher.py` | Added "Fix pie menu positioning" checkbox (Options tab) + standalone "Fix Pie Menu" button |
| `tests/test_patches.py` | 11 new tests for `ExecutablePatchTest` — verification, scaling, code cave, call targets |
| `.gitignore` | Added `*.egg-info/` |

## How to use

### Option A: Full patch (new install)
1. Run the patcher as usual
2. The **"Fix pie menu positioning"** checkbox is enabled by default in the Options tab
3. Click **Patch** — the EXE is patched alongside all other files

### Option B: Add to already-patched game
If the game is already patched (UI packages scaled) and you just want the pie menu fix:
1. Run the patcher and point it to your game folder
2. Click the **"Fix Pie Menu"** button — patches only `Sims2EP9.exe` (takes seconds, not hours)

### Reverting
The EXE is backed up to `Sims2EP9.exe.bak` automatically. Click **Revert** to restore all files including the EXE, or manually copy the `.bak` file back.

## Limitations

- **Only verified on `Sims2EP9.exe`** (Mansion & Garden Stuff / Ultimate Collection). Other EP versions are skipped with a warning if the byte signature doesn't match.
- The code cave offsets are specific to this EXE version. If EA ever re-releases or patches the executable, the byte verification will catch the mismatch and skip gracefully.
- The 1.5x (experimental) scale option should work proportionally but hasn't been tested in-game.

## Tests

All 88 tests pass (11 new):

```
test_verify_original_passes .............. ok
test_verify_wrong_bytes_fails ............ ok
test_verify_wrong_fild_fails ............. ok
test_sector_offsets_scaled_2x ............ ok
test_sector_offsets_scaled_1_5x .......... ok
test_sector_offset_capped_at_127 ......... ok
test_code_cave_written ................... ok
test_call_site_1_redirected .............. ok
test_call_site_2_redirected .............. ok
test_call_targets_are_correct ............ ok
test_unpatched_bytes_preserved ........... ok
```

Tests use synthetic EXE data — no real game files needed in CI.
