### PR TITLE
Feature/rpc exe support

### DIFF
--- a/sims2_4k_ui_patcher.py
+++ b/sims2_4k_ui_patcher.py
@@ -440,9 +440,10 @@ class PatcherApplication(QMainWindow):
         self.patch_executable_option = QCheckBox("Apply additional UI fixes")
         self.patch_executable_option.setChecked(True)
         self.patch_executable_option.setToolTip(
-            "Patches Sims2EP9.exe to scale pie menu item positions.\n"
+            "Patches the game executable to scale pie menu item positions.\n"
             "Fixes overlapping/small pie menus at high resolutions.\n"
-            "Only supported for Mansion & Garden Stuff (Sims2EP9.exe)."
+            "Only supported for Mansion & Garden Stuff (Sims2EP9.exe), including\n"
+            "Sims2EP9RPC.exe used by the Sims 2 RPC launcher."
         )
         self.patch_executable_option.stateChanged.connect(_executable_changed)
         self.tab_options_layout.addRow("Executable:", self.patch_executable_option)

--- a/sims2_4k_ui_patcher.py
+++ b/sims2_4k_ui_patcher.py
@@ -443,7 +443,7 @@ class PatcherApplication(QMainWindow):
             "Patches the game executable to scale pie menu item positions.\n"
             "Fixes overlapping/small pie menus at high resolutions.\n"
             "Only supported for Mansion & Garden Stuff (Sims2EP9.exe), including\n"
-            "Sims2EP9RPC.exe used by the Sims 2 RPC launcher."
+            "the Sims 2 RPC launcher (Sims2EP9RPC.exe)."
         )
         self.patch_executable_option.stateChanged.connect(_executable_changed)
         self.tab_options_layout.addRow("Executable:", self.patch_executable_option)

--- a/sims2patcher/gamefile.py
+++ b/sims2patcher/gamefile.py
@@ -54,10 +54,17 @@ def get_patchable_paths(install_dir: str) -> list[str]:
 
 def get_exe_paths(install_dir: str) -> list[str]:
     """
-    Return paths to Sims2EP9.exe files in the installation directory.
-    Only Sims2EP9.exe is supported for pie menu binary patching.
+    Return paths to game executables in the installation directory that
+    support the pie menu binary patch:
+
+    - Sims2EP9.exe (Mansion & Garden Stuff)
+    - Sims2EP9RPC.exe, a copy of the executable created by the
+      Sims 2 RPC launcher (https://github.com/LazyDuchess/Sims2RPC.com)
     """
-    return glob.glob(install_dir + "/**/Sims2EP9.exe", recursive=True)
+    found: List[str] = []
+    for filename in ["Sims2EP9.exe", "Sims2EP9RPC.exe"]:
+        found += glob.glob(install_dir + f"/**/{filename}", recursive=True)
+    return found
 
 
 def get_game_file(path: str) -> 'GameFile':

--- a/sims2patcher/patches.py
+++ b/sims2patcher/patches.py
@@ -486,7 +486,7 @@ def patch_file(file: gamefile.GameFile, ui_update_progress: Callable):
     elif file.filename in ["ui.package", "CaSIEUI.data", "objects.package"]:
         process_package(file, ui_update_progress)
 
-    elif file.filename.lower() == "sims2ep9.exe" and FIX_PIE_MENU:
+    elif file.filename.lower() in ("sims2ep9.exe", "sims2ep9rpc.exe") and FIX_PIE_MENU:
         process_executable(file)
 
     else:

--- a/tests/test_gamefile.py
+++ b/tests/test_gamefile.py
@@ -88,6 +88,24 @@ class GameFileTest(unittest.TestCase):
         paths = gamefile.get_patchable_paths(self.game_dir)
         gamefile.get_patchable_files(paths)
 
+    def test_exe_paths(self):
+        """Check we find supported executables, including the Sims 2 RPC copy"""
+        tsbin = self._abspath("Test Games/The Sims 2 Mansion and Garden Stuff/TSBin")
+        wanted = [os.path.join(tsbin, "Sims2EP9.exe"), os.path.join(tsbin, "Sims2EP9RPC.exe")]
+        unwanted = [os.path.join(tsbin, "Sims2EP4.exe"), os.path.join(tsbin, "Sims2RPC.exe")]
+
+        os.makedirs(tsbin, exist_ok=True)
+        for path in wanted + unwanted:
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("")
+
+        try:
+            paths = [os.path.normpath(p) for p in gamefile.get_exe_paths(self.game_dir)]
+            self.assertEqual(sorted(paths), sorted(os.path.normpath(p) for p in wanted))
+        finally:
+            for path in wanted + unwanted:
+                os.remove(path)
+
     def test_game_file(self):
         """Check we create the correct kind of GameFile objects"""
         self.assertIsInstance(gamefile.get_game_file(self._abspath("Test Games/The Sims 2/TSData/Res/Objects/objects.package")), gamefile.GameFileOverride)

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -117,6 +117,23 @@ class UIScriptTest(BaseTestCase):
         self.assertEqual(result, expected, "UI script was not upscaled as expected")
 
 
+def make_fake_exe() -> bytearray:
+    """Create a minimal bytearray with correct original bytes at all patch offsets."""
+    max_offset = max(
+        max(o for o, _ in exe_patches._PIE_MENU_SECTOR_OFFSETS),
+        exe_patches._PIE_MENU_FILD_SITE_2 + 9,
+        exe_patches._PIE_MENU_CAVE_ADDR + 40,
+    )
+    data = bytearray(max_offset + 64)
+    for offset, orig_val in exe_patches._PIE_MENU_SECTOR_OFFSETS:
+        data[offset] = orig_val
+    site1 = exe_patches._PIE_MENU_FILD_SITE_1
+    data[site1:site1+8] = exe_patches._PIE_MENU_FILD_ORIG_1
+    site2 = exe_patches._PIE_MENU_FILD_SITE_2
+    data[site2:site2+9] = exe_patches._PIE_MENU_FILD_ORIG_2
+    return data
+
+
 class ExecutablePatchTest(BaseTestCase):
     """
     Test the pie menu binary patching for Sims2EP9.exe.
@@ -124,19 +141,7 @@ class ExecutablePatchTest(BaseTestCase):
     """
     def _make_fake_exe(self) -> bytearray:
         """Create a minimal bytearray with correct original bytes at all patch offsets."""
-        max_offset = max(
-            max(o for o, _ in exe_patches._PIE_MENU_SECTOR_OFFSETS),
-            exe_patches._PIE_MENU_FILD_SITE_2 + 9,
-            exe_patches._PIE_MENU_CAVE_ADDR + 40,
-        )
-        data = bytearray(max_offset + 64)
-        for offset, orig_val in exe_patches._PIE_MENU_SECTOR_OFFSETS:
-            data[offset] = orig_val
-        site1 = exe_patches._PIE_MENU_FILD_SITE_1
-        data[site1:site1+8] = exe_patches._PIE_MENU_FILD_ORIG_1
-        site2 = exe_patches._PIE_MENU_FILD_SITE_2
-        data[site2:site2+9] = exe_patches._PIE_MENU_FILD_ORIG_2
-        return data
+        return make_fake_exe()
 
     def test_verify_original_passes(self):
         """Verification passes for unmodified original bytes"""
@@ -241,3 +246,49 @@ class ExecutablePatchTest(BaseTestCase):
             if i not in patch_ranges:
                 self.assertEqual(result[i], data[i],
                     f"Byte at 0x{i:X} was unexpectedly modified")
+
+
+class ExecutableRoutingTest(BaseTestCase):
+    """
+    Test supported executables are routed through the pie menu patch,
+    based on their filename.
+    """
+    def _patch_fake_exe(self, filename: str) -> str:
+        """Write a synthetic executable and run it through patch_file(). Returns the patched path."""
+        data = bytes(make_fake_exe())
+
+        backup_path = self.mktemp()
+        with open(backup_path, "wb") as f:
+            f.write(data)
+
+        tmp_path = os.path.join(os.path.dirname(backup_path), filename)
+        with open(tmp_path, "wb") as f:
+            f.write(data)
+        self.tmp_files.append(tmp_path)
+        self.tmp_files.append(tmp_path + ".patched")
+
+        patches.UI_MULTIPLIER = 2.0
+        patches.FIX_PIE_MENU = True
+
+        dummy_file = GameFileReplacement(tmp_path)
+        dummy_file._backup_path = backup_path
+        patches.patch_file(dummy_file, lambda current, total: None)
+
+        self.assertTrue(dummy_file.patched, f"{filename} was not patched")
+        return tmp_path
+
+    def test_exe_patched(self):
+        """Sims2EP9.exe is patched with scaled sector offsets"""
+        path = self._patch_fake_exe("Sims2EP9.exe")
+        with open(path, "rb") as f:
+            result = f.read()
+        offset, orig_val = exe_patches._PIE_MENU_SECTOR_OFFSETS[0]
+        self.assertEqual(result[offset], orig_val * 2, "Sector offset was not scaled")
+
+    def test_rpc_exe_patched(self):
+        """Sims2EP9RPC.exe (Sims 2 RPC launcher) is patched with scaled sector offsets"""
+        path = self._patch_fake_exe("Sims2EP9RPC.exe")
+        with open(path, "rb") as f:
+            result = f.read()
+        offset, orig_val = exe_patches._PIE_MENU_SECTOR_OFFSETS[0]
+        self.assertEqual(result[offset], orig_val * 2, "Sector offset was not scaled")


### PR DESCRIPTION
Thank you for creating such a wonderful utility, its great being able to run the game without worrying about upscaling. 

I was not able to take advantage of the recent pie menu fixes since I use Sims2RPC, which has its own patched executable. I asked Claude to add support for the Sims2EP9RPC executable, and this is the result. I did review and test the changes in my own game, but I don't have enough Python knowledge to evaluate the code quality. 

Claude's summary of changes:

> gamefile.py — get_exe_paths() now finds both Sims2EP9.exe and Sims2EP9RPC.exe
> patches.py — routing accepts both filenames; the existing verify_exe_bytes() check still guards anyone whose RPC exe is a different version (patch skipped gracefully)
> GUI tooltip mentions the RPC executable
> Tests: discovery test (finds both, ignores Sims2RPC.exe launcher and other EP exes) and two routing tests using the synthetic-exe helper, which I lifted to a module-level function so both test classes share it

And verification:

> Full suite passes: 91 tests on the RPC branch standalone
> Against real data: discovery finds both executables under C:\Games\The Sims 2, and patching a temp copy of your actual Sims2EP9RPC.exe produced output byte-identical to your already-patched Sims2EP9.exe — expected, since the sources are identical copies

The end result in my game (with Clean UI!):
<img width="1022" height="640" alt="Screenshot 2026-07-09 100641" src="https://github.com/user-attachments/assets/82d4a9f9-7e87-4775-ba91-b1f97d9ebf78" />

This PR only includes the executable patch changes, I'm still testing the Clean UI functionality to make sure it works with other UI mods.